### PR TITLE
Remove unnecessary lines.

### DIFF
--- a/default/source/MenuState.hx
+++ b/default/source/MenuState.hx
@@ -11,7 +11,7 @@ class MenuState extends FlxState
 {
 	override public function create():Void
 	{
-		super.create();
+		
 	}
 
 	override public function update(elapsed:Float):Void

--- a/default/source/PlayState.hx
+++ b/default/source/PlayState.hx
@@ -11,7 +11,7 @@ class PlayState extends FlxState
 {
 	override public function create():Void
 	{
-		super.create();
+		
 	}
 
 	override public function update(elapsed:Float):Void


### PR DESCRIPTION
In both HaxeFlixel stable and dev, super.create() (i.e. FlxState.create()) is empty.

If this is accepted I can update the tutorial docs to match.