### PR TITLE
specific lime version in project.xml

### DIFF
--- a/default/Project.xml.tpl
+++ b/default/Project.xml.tpl
@@ -33,6 +33,8 @@
 
 	<!-- _______________________________ Libraries ______________________________ -->
 
+	<!--For capability reason-->
+	<haxelib name="lime" version="2.9.1" />
 	<haxelib name="flixel" />
 
 	<!--In case you want to use the addons package-->


### PR DESCRIPTION
Also, I think HaxeFlixel/flixel#1820 should be closed since there are `#abort` for lime and openfl in `FlxDefine`.