### PR TITLE
Fix .xsd links

### DIFF
--- a/default/Project.xml.tpl
+++ b/default/Project.xml.tpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.software/xsd/project-1.0.2.xsd">
+	xsi:schemaLocation="http://lime.software/project/1.0.2 http://openfl.github.io/lime.software/xsd/project-1.0.2.xsd">
 
 	<!-- _________________________ Application Settings _________________________ -->
 

--- a/ide-data/flash-develop-fdz/$(BaseDir)/Projects/395 Haxe - HaxeFlixel Project/Project.xml.template
+++ b/ide-data/flash-develop-fdz/$(BaseDir)/Projects/395 Haxe - HaxeFlixel Project/Project.xml.template
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.software/xsd/project-1.0.2.xsd">
+	xsi:schemaLocation="http://lime.software/project/1.0.2 http://openfl.github.io/lime.software/xsd/project-1.0.2.xsd">
 
 	<!-- _________________________ Application Settings _________________________ -->
 	


### PR DESCRIPTION
Read this issue: #37
https://github.com/openfl/lime/commit/8d715cb741d7945137fc691aa5509f8162a37e7f

Recently lime.software have been moved to openfl.github.io/lime.software

This pull request fix the Project.xml file linting and code completion by changing http://lime.software/xsd/project-1.0.2.xsd to http://openfl.github.io/lime.software/xsd/project-1.0.2.xsd

Tested on VSCode using Red Hat's XML Extension