### PR TITLE
Fix .xsd links (again)

### DIFF
--- a/default/Project.xml.tpl
+++ b/default/Project.xml.tpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://lime.software/project/1.0.2 http://openfl.github.io/lime.software/xsd/project-1.0.2.xsd">
+	xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.openfl.org/xsd/project-1.0.2.xsd">
 
 	<!-- _________________________ Application Settings _________________________ -->
 

--- a/default/Project.xml.tpl
+++ b/default/Project.xml.tpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://lime.openfl.org/project/1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://lime.openfl.org/project/1.0.4" "http://lime.openfl.org/xsd/project-1.0.4.xsd">
+	xsi:schemaLocation="http://lime.openfl.org/project/1.0.4 http://lime.openfl.org/xsd/project-1.0.4.xsd">
 
 	<!-- _________________________ Application Settings _________________________ -->
 

--- a/default/Project.xml.tpl
+++ b/default/Project.xml.tpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://lime.openfl.org/project/1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://lime.openfl.org/project/1.0.4" http://lime.openfl.org/xsd/project-1.0.4.xsd">
+	xsi:schemaLocation="http://lime.openfl.org/project/1.0.4" "http://lime.openfl.org/xsd/project-1.0.4.xsd">
 
 	<!-- _________________________ Application Settings _________________________ -->
 

--- a/default/Project.xml.tpl
+++ b/default/Project.xml.tpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.openfl.org/xsd/project-1.0.2.xsd">
+<project xmlns="http://lime.openfl.org/project/1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://lime.openfl.org/project/1.0.4" http://lime.openfl.org/xsd/project-1.0.4.xsd">
 
 	<!-- _________________________ Application Settings _________________________ -->
 

--- a/ide-data/flash-develop-fdz/$(BaseDir)/Projects/395 Haxe - HaxeFlixel Project/Project.xml.template
+++ b/ide-data/flash-develop-fdz/$(BaseDir)/Projects/395 Haxe - HaxeFlixel Project/Project.xml.template
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.openfl.org/xsd/project-1.0.2.xsd">
+<project xmlns="http://lime.openfl.org/project/1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://lime.openfl.org/project/1.0.4 http://lime.openfl.org/xsd/project-1.0.4.xsd">
 
 	<!-- _________________________ Application Settings _________________________ -->
 	

--- a/ide-data/flash-develop-fdz/$(BaseDir)/Projects/395 Haxe - HaxeFlixel Project/Project.xml.template
+++ b/ide-data/flash-develop-fdz/$(BaseDir)/Projects/395 Haxe - HaxeFlixel Project/Project.xml.template
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://lime.software/project/1.0.2 http://openfl.github.io/lime.software/xsd/project-1.0.2.xsd">
+	xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.openfl.org/xsd/project-1.0.2.xsd">
 
 	<!-- _________________________ Application Settings _________________________ -->
 	


### PR DESCRIPTION
lime's new domain is now
lime.openfl.org

this pull request fix the broken .xsd links again.

Edit: there's a new version of .xsd, waiting to release on the repo