### PR TITLE
change resizable="true" in Project.xml template

### DIFF
--- a/default/Project.xml.tpl
+++ b/default/Project.xml.tpl
@@ -19,7 +19,7 @@
 	<window width="${WIDTH}" height="${HEIGHT}" fps="60" background="#000000" hardware="true" vsync="false" />
 
 	<!--HTML5-specific-->
-	<window if="html5" resizable="false" />
+	<window if="html5" resizable="true" />
 
 	<!--Desktop-specific-->
 	<window if="desktop" orientation="landscape" fullscreen="false" resizable="true" />


### PR DESCRIPTION
I believe this is where I should put it!

changes the default 
```xml
<!--HTML5-specific-->
<window if="html5" resizable="false" />
```
to
```xml
<!--HTML5-specific-->
<window if="html5" resizable="true" />
```

`resizable="true"` allows the html canvas to stretch to whatever viewport size it's within. 

Should only affect new projects being made (as its a template) and really only has effects on instances where someone changes the scaling mode (which someone should know how to change / configure this anyways how they'd need)