### PR TITLE
Project.xml additions

### DIFF
--- a/default/Project.xml.tpl
+++ b/default/Project.xml.tpl
@@ -51,12 +51,12 @@
 	<!--Allows you to use sound paths with no extension, and the default sound type for that
 		target will be used. If enabled it will use ogg on all targets except flash, which uses mp3.
 		If value is set to any string, that is used for the file extension-->
-	<!--<haxedef name="FLX_DEFAULT_SOUND_EXT" value="" />-->
+	<!--<haxedef name="FLX_DEFAULT_SOUND_EXT" />-->
 
 	<!--Loads from the specified relative or absolute directory. Unlike other boolean flags, this flag should contain a string value.
 		When using assets entirely from outside the build directory, it is wise to disable any 
 		<assets> tags in your project.xml, to reduce your total memory-->
-	<!--<haxedef name="FLX_CUSTOM_ASSETS_DIRECTORY" value="" />-->
+	<!--<haxedef name="FLX_CUSTOM_ASSETS_DIRECTORY" value="assets" />-->
 
 	<!--Remove the legacy health system-->
 	<haxedef name="FLX_NO_HEALTH" />

--- a/default/Project.xml.tpl
+++ b/default/Project.xml.tpl
@@ -49,7 +49,7 @@
 	<!-- ______________________________ Haxedefines _____________________________ -->
 
 	<!--Allows you to use sound paths with no extension, and the default sound type for that
-	 	target will be used. If enabled it will use ogg on all targets except flash, which uses mp3.
+		target will be used. If enabled it will use ogg on all targets except flash, which uses mp3.
 		If value is set to any string, that is used for the file extension-->
 	<!--<haxedef name="FLX_DEFAULT_SOUND_EXT" value="" />-->
 

--- a/default/Project.xml.tpl
+++ b/default/Project.xml.tpl
@@ -48,6 +48,16 @@
 
 	<!-- ______________________________ Haxedefines _____________________________ -->
 
+	<!--Allows you to use sound paths with no extension, and the default sound type for that
+	 	target will be used. If enabled it will use ogg on all targets except flash, which uses mp3.
+		If value is set to any string, that is used for the file extension-->
+	<!--<haxedef name="FLX_DEFAULT_SOUND_EXT" value="" />-->
+
+	<!--Loads from the specified relative or absolute directory. Unlike other boolean flags, this flag should contain a string value.
+		When using assets entirely from outside the build directory, it is wise to disable any 
+		<assets> tags in your project.xml, to reduce your total memory-->
+	<!--<haxedef name="FLX_CUSTOM_ASSETS_DIRECTORY" value="" />-->
+
 	<!--Remove the legacy health system-->
 	<haxedef name="FLX_NO_HEALTH" />
 	
@@ -77,6 +87,9 @@
 
 	<!--Disable the Flixel core debugger. Automatically gets set whenever you compile in release mode!-->
 	<haxedef name="FLX_NO_DEBUG" unless="debug" />
+
+	<!--Disable the Flixel save system-->
+	<!--<haxedef name="FLX_NO_SAVE" />-->
 
 	<!--Enable this for Nape release builds for a serious peformance improvement-->
 	<haxedef name="NAPE_RELEASE_BUILD" unless="debug" />


### PR DESCRIPTION
Adds the defines mentioned in #43

I've added `FLX_DEFAULT_SOUND_EXT` and `FLX_CUSTOM_ASSETS_DIRECTORY` to the beginning of the haxedefines section because I feel like they're useful features and could benefit from the visibility. I also copied their docs from FlxDefines but with slight tweaks